### PR TITLE
Fix crash server on restart

### DIFF
--- a/src/Cfpve.cpp
+++ b/src/Cfpve.cpp
@@ -24,6 +24,9 @@ void temporaryFactionChange(Player* player)
 
     Player* leader = group->GetLeader();
 
+    if (!leader)
+        return;
+
     player->SetFaction(leader->GetFaction());
 }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- When restarting the server or suffering a crash and not finding the leader, the pointer causes a crash.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In game.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Enable crossfaction and play between alliances and hordes within Icecrown Citadel stays.
2. Simulate a fall to force the change of faction in the room and check that there is no crash.
